### PR TITLE
Updating dependencies to remediate critical vulnerabilities

### DIFF
--- a/galasa-simplatform-application/galasa-simplatform-3270/pom.xml
+++ b/galasa-simplatform-application/galasa-simplatform-3270/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.zos.manager</artifactId>
-			<version>0.15.0</version>
+			<version>0.31.0</version>
 		</dependency>
 	</dependencies>
 

--- a/galasa-simplatform-application/galasa-simplatform-3270/src/main/java/dev/galasa/simplatform/t3270/screens/AbstractScreen.java
+++ b/galasa-simplatform-application/galasa-simplatform-3270/src/main/java/dev/galasa/simplatform/t3270/screens/AbstractScreen.java
@@ -164,7 +164,7 @@ public abstract class AbstractScreen implements IScreen {
                 buffer.get(cursor);
 
                 if (buffer.hasRemaining()) {
-                    List<AbstractOrder> orders = NetworkThread.processOrders(buffer);
+                    List<AbstractOrder> orders = NetworkThread.processOrders(buffer, screen.getCodePage());
 
                     screen.processOrders(orders, new WriteControlCharacter());
                 }

--- a/galasa-simplatform-application/pom.xml
+++ b/galasa-simplatform-application/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.zos3270.manager</artifactId>
-			<version>0.15.0</version>
+			<version>0.31.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Updated dev.galasa.zos.manager and dev.galasa.zos3270.manager to dependency 0.31.0 and updated changed functions
Signed-off-by: Fiona Ampofo <64271621+Akyiaa@users.noreply.github.com>
