### PR TITLE
Removed access control allow origin header with any origin

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -73,7 +73,7 @@ Options are:
 Environment Variables:
 SOURCE_MAVEN :
     Used to indicate where parts of the OBR can be obtained.
-    Optional. Defaults to https://galasadev-cicsk8s.hursley.ibm.com/main/maven/obr/
+    Optional. Defaults to https://development.galasa.dev/main/maven-repo/obr/
      
 LOGS_DIR :
     Controls where logs are placed. 

--- a/galasa-simplatform-application/galasa-simplatform-webapp/src/main/java/SimbankServlet.java
+++ b/galasa-simplatform-application/galasa-simplatform-webapp/src/main/java/SimbankServlet.java
@@ -45,7 +45,6 @@ public class SimbankServlet extends HttpServlet {
 
 		RequestDispatcher rd = request.getRequestDispatcher("/index.html");
 
-		response.setHeader("Access-Control-Allow-Origin", "*");
 		rd.include(request, response);
 
 
@@ -75,7 +74,6 @@ public class SimbankServlet extends HttpServlet {
 				Request post = Request.Post("http://host.docker.internal:2080/updateAccount").bodyString(xml, ContentType.APPLICATION_XML);
 				Response resp = post.execute();
 				HttpResponse simbankResp = resp.returnResponse();
-				response.setHeader("Access-Control-Allow-Origin", "*");
 				int statusCode = simbankResp.getStatusLine().getStatusCode();
 				response.reset();
 				response.setStatus(statusCode);


### PR DESCRIPTION
## Why?

Removed the Access-Control-Allow-Origin HTTP response header that allows any origin to receive the response from the SimbankServlet.

Also updated outdated URL in the build locally script.