### PR TITLE
Bump dev.galasa versions to 0.38.0 and simplatform to 0.38.0

### DIFF
--- a/galasa-simbank-tests/dev.galasa.simbank.gherkin.tests/pom.xml
+++ b/galasa-simbank-tests/dev.galasa.simbank.gherkin.tests/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>dev.galasa</groupId>
     <artifactId>galasa-simbanktests-parent</artifactId>
-    <version>0.25.0</version>
+    <version>0.38.0</version>
   </parent>
   
   <artifactId>dev.galasa.simbank.gherkin.tests</artifactId>
-  <version>0.25.0</version>
+  <version>0.38.0</version>
   <packaging>galasa-gherkin</packaging>
   
 </project>

--- a/galasa-simbank-tests/dev.galasa.simbank.manager/pom-example.xml
+++ b/galasa-simbank-tests/dev.galasa.simbank.manager/pom-example.xml
@@ -23,7 +23,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>galasa-bom</artifactId>
-				<version>0.25.0</version>
+				<version>0.38.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/galasa-simbank-tests/dev.galasa.simbank.manager/pom.xml
+++ b/galasa-simbank-tests/dev.galasa.simbank.manager/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-simbanktests-parent</artifactId>
-		<version>0.25.0</version>
+		<version>0.38.0</version>
 	</parent>
 	
 	<name>Galasa SimBank Manager</name>
 
 	<artifactId>dev.galasa.simbank.manager</artifactId>
-	<version>0.25.0</version>
+	<version>0.38.0</version>
 	<!-- If updating version, reflect in dev.galasa.simbank.feature, dev.galasa.simbank.tests and dev.galasa.simbank.obr -->
 	<packaging>bundle</packaging>
 

--- a/galasa-simbank-tests/dev.galasa.simbank.obr/pom.xml
+++ b/galasa-simbank-tests/dev.galasa.simbank.obr/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-simbanktests-parent</artifactId>
-		<version>0.25.0</version>
+		<version>0.38.0</version>
 	</parent>
 
 	<name>Galasa SimBank OBR</name>
 
 	<artifactId>dev.galasa.simbank.obr</artifactId>
-	<version>0.25.0</version>
+	<version>0.38.0</version>
 	<!-- If updating version, reflect change in build/docker/testcatalogs/pom.xml -->
 	<packaging>galasa-obr</packaging>
 
@@ -25,13 +25,13 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.simbank.tests</artifactId>
-			<version>0.25.0</version>
+			<version>0.38.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.simbank.manager</artifactId>
-			<version>0.25.0</version>
+			<version>0.38.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/galasa-simbank-tests/dev.galasa.simbank.tests/pom-example.xml
+++ b/galasa-simbank-tests/dev.galasa.simbank.tests/pom-example.xml
@@ -23,7 +23,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>galasa-bom</artifactId>
-				<version>0.25.0</version>
+				<version>0.38.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/galasa-simbank-tests/dev.galasa.simbank.tests/pom.xml
+++ b/galasa-simbank-tests/dev.galasa.simbank.tests/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>dev.galasa</groupId>
 		<artifactId>galasa-simbanktests-parent</artifactId>
-		<version>0.25.0</version>
+		<version>0.38.0</version>
 	</parent>
 	
 	<name>Galasa SimBank Example Tests</name>
 
 	<artifactId>dev.galasa.simbank.tests</artifactId>
-	<version>0.25.0</version>
+	<version>0.38.0</version>
 	<!-- If updating version, reflect in dev.galasa.simbank.feature and dev.galasa.simbank.obr -->
 	<packaging>bundle</packaging>
 
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.simbank.manager</artifactId>
-			<version>0.25.0</version>
+			<version>0.38.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/galasa-simbank-tests/pom.xml
+++ b/galasa-simbank-tests/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-simbanktests-parent</artifactId>
-	<version>0.25.0</version>
+	<version>0.38.0</version>
 	<!-- If updating version,  reflect change in dev.galasa.simbank.ui -->
 	<packaging>pom</packaging>
 
@@ -76,7 +76,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>galasa-bom</artifactId>
-				<version>0.25.0</version>
+				<version>0.38.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/galasa-simplatform-application/galasa-simplatform-3270/pom.xml
+++ b/galasa-simplatform-application/galasa-simplatform-3270/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.zos.manager</artifactId>
-			<version>0.31.0</version>
+			<version>0.38.0</version>
 		</dependency>
 	</dependencies>
 

--- a/galasa-simplatform-application/pom.xml
+++ b/galasa-simplatform-application/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.zos3270.manager</artifactId>
-			<version>0.31.0</version>
+			<version>0.38.0</version>
 		</dependency>
 
 		<dependency>

--- a/test-locally.sh
+++ b/test-locally.sh
@@ -114,7 +114,7 @@ h1 "Running Simbank application tests"
 
 checkGalasaCtlAvailable
 
-TEST_OBR_VERSION="0.25.0"
+TEST_OBR_VERSION="0.38.0"
 
 mkdir -p ${BASEDIR}/temp
 cd ${BASEDIR}/temp


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2066

The simplatform jar still contained references to log4j 2.17.1 even though it was bumped up to 2.24.1. By bumping the galasa-bom to 0.38.0 in simplatform, the jar now correctly references 2.24.1.

## Changes
- Bumped references to galasa-bom to 0.38.0
- Bumped simplatform and simbank test versions to 0.38.0
- Bumped references to managers like the zos and zos3270 managers to 0.38.0