### PR TITLE
Iss2054 - Upgrade assertj-core version

### DIFF
--- a/galasa-simbank-tests/dev.galasa.simbank.tests/build-example.gradle
+++ b/galasa-simbank-tests/dev.galasa.simbank.tests/build-example.gradle
@@ -24,6 +24,6 @@ dependencies {
     implementation 'dev.galasa:dev.galasa.zos.manager:0.+'
     implementation 'dev.galasa:dev.galasa.zos3270.manager:0.+'
     
-    implementation 'org.assertj:assertj-core:3.11.+'
+    implementation 'org.assertj:assertj-core:3.25.+'
     
 }


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2054

- Ensures consistent version of assertj-core used throughout Galasa
- Removes a Medium vulnerability from a junit dependency of assertj-core