### PR TITLE
Issue 2190 - Set up new Simbank tests to replace inttests

### DIFF
--- a/.galasa/cps.properties
+++ b/.galasa/cps.properties
@@ -2,8 +2,8 @@
 # File: cps.properties
 #
 # Purpose:
-#   To provide properties to the Galasa runtime when not using a
-#   Galasa ecosystem. ie: When running locally with a JVM.
+#   To provide properties to the Galasa runtime when running tests in a local JVM. 
+#   These properties are used in the test.yaml Github Actions workflow.
 #
 
 simbank.dse.instance.name=SIMBANK

--- a/.galasa/cps.properties
+++ b/.galasa/cps.properties
@@ -1,0 +1,14 @@
+#
+# File: cps.properties
+#
+# Purpose:
+#   To provide properties to the Galasa runtime when not using a
+#   Galasa ecosystem. ie: When running locally with a JVM.
+#
+
+zos.dse.tag.SIMBANK.imageid=SIMBANK
+zos.image.SIMBANK.ipv4.hostname=127.0.0.1
+zos.image.SIMBANK.telnet.tls=false
+zos.image.SIMBANK.telnet.port=2023
+zos.image.SIMBANK.webnet.port=2080
+zos.image.SIMBANK.credentials=SIMBANK

--- a/.galasa/cps.properties
+++ b/.galasa/cps.properties
@@ -6,6 +6,10 @@
 #   Galasa ecosystem. ie: When running locally with a JVM.
 #
 
+simbank.dse.instance.name=SIMBANK
+simbank.instance.SIMBANK.zos.image=SIMBANK
+simbank.instance.SIMBANK.credentials.id=SIMBANK
+
 zos.dse.tag.SIMBANK.imageid=SIMBANK
 zos.image.SIMBANK.ipv4.hostname=127.0.0.1
 zos.image.SIMBANK.telnet.tls=false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,11 +148,11 @@ jobs:
         run: |
           docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-simplatform --resource apps:Deployment:simplatform-${{ env.BRANCH }} --health --server argocd.galasa.dev
 
-  # run-simbank-tests:
-  #   name: Run the SimBank Tests
-  #   needs: [build-simplatform]
-  #   uses: ./.github/workflows/test.yaml
-  #   secrets: inherit
+  run-simbank-tests:
+    name: Run the SimBank Tests
+    needs: [build-simplatform]
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
 
   report-failure:
     # Skip this job for forks

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,12 @@ jobs:
           path: galasa-simbank-tests-build.log
           retention-days: 7
 
+      - name: Upload Simplatform
+        uses: actions/upload-artifact@v4
+        with:
+          name: simplatform
+          path: /home/runner/.m2/repository
+
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         with:
@@ -141,6 +147,12 @@ jobs:
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
           docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-simplatform --resource apps:Deployment:simplatform-${{ env.BRANCH }} --health --server argocd.galasa.dev
+
+  # run-simbank-tests:
+  #   name: Run the SimBank Tests
+  #   needs: [build-simplatform]
+  #   uses: ./.github/workflows/test.yaml
+  #   secrets: inherit
 
   report-failure:
     # Skip this job for forks

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,10 +69,6 @@ jobs:
           brew install --no-quarantine galasactl
     #----------------------------------------------------------------------------------
     # Set up Galasa environment
-      - name: Make Galasa home directory
-        run: |
-          mkdir ${{ env.GALASA_HOME }}
-
       - name: Create credentials.properties file
         working-directory: ${{ env.GALASA_HOME }}
         run: |
@@ -128,6 +124,28 @@ jobs:
           --obr mvn:dev.galasa/dev.galasa.simbank.obr/${GALASA_VERSION}/obr \
           --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \
           --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT \
+          --remoteMaven https://development.galasa.dev/main/maven-repo/obr \
+          --log -
+
+      - name: Run the BasicAccountCreditTest
+        env:
+          GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
+        run: |
+          galasactl runs submit local \
+          --obr mvn:dev.galasa/dev.galasa.simbank.obr/${GALASA_VERSION}/obr \
+          --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \
+          --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest \
+          --remoteMaven https://development.galasa.dev/main/maven-repo/obr \
+          --log -
+
+      - name: Run the ProvisionedAccountCreditTests
+        env:
+          GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
+        run: |
+          galasactl runs submit local \
+          --obr mvn:dev.galasa/dev.galasa.simbank.obr/${GALASA_VERSION}/obr \
+          --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \
+          --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.ProvisionedAccountCreditTests \
           --remoteMaven https://development.galasa.dev/main/maven-repo/obr \
           --log -
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
           path: ${{ github.workspace }}/simplatform
             
 
-      - name: Build Simplatform application
+      - name: Build Simplatform
         working-directory: ${{ github.workspace }}/simplatform
         run: |
           ./build-locally.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Build Simplatform
         working-directory: ${{ github.workspace }}/simplatform
         run: |
-          ./build-locally.sh
+          ./build-locally.sh --skip-docker --skip-secrets
 
     #----------------------------------------------------------------------------------
     # Set up Galasa environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@
 name: Test SimBank
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: [main]
@@ -18,7 +19,7 @@ jobs:
     name: Get Galasa Version
     # Use the build.properties file in the galasa repo to source the galasa-version output variable.
     # This variable can be referenced by other jobs in this flow using ${{ needs.get-galasa-version.outputs.galasa-version }}
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout 'galasa' repository
@@ -37,33 +38,39 @@ jobs:
     outputs:
       galasa-version: ${{ steps.get-galasa-version.outputs.GALASA_VERSION }}
 
-  run-simbank-tests:
-    name: Run SimBank Tests
-    runs-on: ubuntu-latest
+  build-and-run-simbank-tests:
+    name: Build and Run SimBank Tests
+    runs-on: macos-latest
 
-    needs: get-galasa-version
+    needs: [get-galasa-version]
 
     env:
       GALASA_HOME: ${{ github.workspace }}/.galasa
 
     steps:
-
     #----------------------------------------------------------------------------------
-    # Build the Simplatform application that the tests connect to
-      - name: Checkout the Simplatform repository
-        uses: actions/checkout@v4
+    # Set up pre-requesite technology (Java, Gradle and galasactl)
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          repository: ${{ env.NAMESPACE }}/simplatform
-          path: ${{ github.workspace }}/simplatform
-            
+          java-version: '17'
+          distribution: 'semeru'
 
-      - name: Build Simplatform
-        working-directory: ${{ github.workspace }}/simplatform
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: '8.9'
+
+      - name: Install galasactl with Homebrew
         run: |
-          ./build-locally.sh --skip-docker --skip-secrets
-
+          brew tap galasa-dev/tap
+          brew install --no-quarantine galasactl
     #----------------------------------------------------------------------------------
     # Set up Galasa environment
+      - name: Make Galasa home directory
+        run: |
+          mkdir ${{ env.GALASA_HOME }}
+
       - name: Create credentials.properties file
         working-directory: ${{ env.GALASA_HOME }}
         run: |
@@ -79,6 +86,28 @@ jobs:
             galasactl local init --log -
 
     #----------------------------------------------------------------------------------
+    # Download or build the Simplatform application that the tests connect to
+      - name: Download SimBank from Main Build
+        if: ${{ github.event.name == 'workflow_call' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: simplatform
+          path: /home/runner/.m2/repository
+        
+      - name: Checkout the Simplatform repository
+        if: ${{ github.event.name == 'workflow_dispatch' || github.event.name == 'push' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.NAMESPACE }}/simplatform
+          path: ${{ github.workspace }}/simplatform
+
+      - name: Build SimBank using local build script
+        if: ${{ github.event.name == 'workflow_dispatch' || github.event.name == 'push' }}
+        working-directory: ${{ github.workspace }}/simplatform
+        run: |
+          ./build-locally.sh --skip-docker --skip-secrets
+
+    #----------------------------------------------------------------------------------
     # Run the Simplatform application 
       - name: Start the Simplatform application
         env:
@@ -89,26 +118,8 @@ jobs:
 
     #----------------------------------------------------------------------------------
     # Run the Simbank tests
-    #   - name: Ensure permissions for mounted /galasa directory
-    #     run: |
-    #       sudo mkdir -p ${{ github.workspace }}/galasa
-    #       sudo chown -R 999:999 ${{ github.workspace }}/galasa
-
-    #   - name: Clean /galasa workspace in CLI image
-    #     run: |
-    #       docker run --rm \
-    #       --user galasa:galasa \
-    #       -v ${{ github.workspace }}/galasa:/galasa \
-    #       ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
-    #       rm -rf /galasa/*
-
       - name: Run the SimBankIVT
         run: |
-          docker run --rm \
-          --env GALASA_HOME=${{ env.GALASA_HOME }} \
-          --user galasa:galasa \
-          -v ${{ github.workspace }}/galasa:/galasa:rw \
-          ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
           galasactl runs submit local \
           --obr mvn:dev.galasa/dev.galasa.simbank.obr/${GALASA_VERSION}/obr \
           --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,10 +6,12 @@
 name: Test SimBank
 
 on:
+  # This workflow_call is used after the Main Build of Simplatform.
   workflow_call:
+  # This workflow_dispatch allows this workflow to be called by a 
+  # scheduled regression run in the Automation repository. It also
+  # allows this workflow to be called by pressing 'Run Workflow'.
   workflow_dispatch:
-  push:
-    branches: [main]
 
 env:
   NAMESPACE: ${{ github.repository_owner }}
@@ -88,21 +90,21 @@ jobs:
     #----------------------------------------------------------------------------------
     # Download or build the Simplatform application that the tests connect to
       - name: Download SimBank from Main Build
-        if: ${{ github.event.name == 'workflow_call' }}
+        if: ${{ github.event_name == 'workflow_call' }}
         uses: actions/download-artifact@v4
         with:
           name: simplatform
           path: /home/runner/.m2/repository
         
       - name: Checkout the Simplatform repository
-        if: ${{ github.event.name == 'workflow_dispatch' || github.event.name == 'push' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.NAMESPACE }}/simplatform
           path: ${{ github.workspace }}/simplatform
 
       - name: Build SimBank using local build script
-        if: ${{ github.event.name == 'workflow_dispatch' || github.event.name == 'push' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         working-directory: ${{ github.workspace }}/simplatform
         run: |
           ./build-locally.sh --skip-docker --skip-secrets

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,8 +81,8 @@ jobs:
             echo "${{ secrets.SIMBANK_CREDENTIALS }}" >> credentials.properties
     
         # The credentials.properties file should look something like this:
-        # secure.credentials.MYSIMBANKUSER.username=XXX
-        # secure.credentials.MYSIMBANKUSER.password=XXX
+        # secure.credentials.SIMBANK.username=XXX
+        # secure.credentials.SIMBANK.password=XXX
         # Needs to be created dynamically as they cannot be checked into GitHub and exposed.
 
       - name: Initialise local Galasa environment to create remaining files and folders

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Get Galasa Version from build.properties file
         id: get-galasa-version
         run: |
-          cat build.properties | grep "=" >> $GITHUB_OUTPUT
+          cat ${{ github.workspace }}/galasa/build.properties | grep "=" >> $GITHUB_OUTPUT
 
     outputs:
       galasa-version: ${{ steps.get-galasa-version.outputs.GALASA_VERSION }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,6 +128,7 @@ jobs:
           --obr mvn:dev.galasa/dev.galasa.simbank.obr/${GALASA_VERSION}/obr \
           --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \
           --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT \
+          --remoteMaven https://development.galasa.dev/main/maven-repo/obr \
           --log -
 
       # - name: Report results into Slack channel

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,130 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Test SimBank
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+env:
+  NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  get-galasa-version:
+    name: Get Galasa Version
+    # Use the build.properties file in the galasa repo to source the galasa-version output variable.
+    # This variable can be referenced by other jobs in this flow using ${{ needs.get-galasa-version.outputs.galasa-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 'galasa' repository
+        uses: actions/checkout@v4  
+        with:
+          repository: ${{ env.NAMESPACE }}/galasa
+          path: ${{ github.workspace }}/galasa
+          sparse-checkout: |
+            build.properties
+
+      - name: Get Galasa Version from build.properties file
+        id: get-galasa-version
+        run: |
+          cat build.properties | grep "=" >> $GITHUB_OUTPUT
+
+    outputs:
+      galasa-version: ${{ steps.get-galasa-version.outputs.GALASA_VERSION }}
+
+  run-simbank-tests:
+    name: Run SimBank Tests
+    runs-on: ubuntu-latest
+
+    needs: get-galasa-version
+
+    env:
+      GALASA_HOME: ${{ github.workspace }}/.galasa
+
+    steps:
+
+    #----------------------------------------------------------------------------------
+    # Build the Simplatform application that the tests connect to
+      - name: Checkout the Simplatform repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.NAMESPACE }}/simplatform
+          path: ${{ github.workspace }}/simplatform
+            
+
+      - name: Build Simplatform application
+        working-directory: ${{ github.workspace }}/simplatform
+        run: |
+          ./build-locally.sh
+
+    #----------------------------------------------------------------------------------
+    # Set up Galasa environment
+      - name: Create credentials.properties file
+        working-directory: ${{ env.GALASA_HOME }}
+        run: |
+            echo "${{ secrets.SIMBANK_CREDENTIALS }}" >> credentials.properties
+    
+        # The credentials.properties file should look something like this:
+        # secure.credentials.MYSIMBANKUSER.username=XXX
+        # secure.credentials.MYSIMBANKUSER.password=XXX
+        # Needs to be created dynamically as they cannot be checked into GitHub and exposed.
+
+      - name: Initialise local Galasa environment to create remaining files and folders
+        run: |
+            galasactl local init --log -
+
+    #----------------------------------------------------------------------------------
+    # Run the Simplatform application 
+      - name: Start the Simplatform application
+        env:
+          GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
+        run: |
+          echo "Starting SimBank application..."
+          java -jar /Users/runner/.m2/repository/dev/galasa/galasa-simplatform/${GALASA_VERSION}/galasa-simplatform-${GALASA_VERSION}.jar &
+
+    #----------------------------------------------------------------------------------
+    # Run the Simbank tests
+    #   - name: Ensure permissions for mounted /galasa directory
+    #     run: |
+    #       sudo mkdir -p ${{ github.workspace }}/galasa
+    #       sudo chown -R 999:999 ${{ github.workspace }}/galasa
+
+    #   - name: Clean /galasa workspace in CLI image
+    #     run: |
+    #       docker run --rm \
+    #       --user galasa:galasa \
+    #       -v ${{ github.workspace }}/galasa:/galasa \
+    #       ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
+    #       rm -rf /galasa/*
+
+      - name: Run the SimBankIVT
+        run: |
+          docker run --rm \
+          --env GALASA_HOME=${{ env.GALASA_HOME }} \
+          --user galasa:galasa \
+          -v ${{ github.workspace }}/galasa:/galasa:rw \
+          ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
+          galasactl runs submit local \
+          --obr mvn:dev.galasa/dev.galasa.simbank.obr/${GALASA_VERSION}/obr \
+          --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \
+          --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT \
+          --log -
+
+      # - name: Report results into Slack channel
+      #   env: 
+      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      #   run: |
+      #     docker run --rm \
+      #     --env SLACK_WEBHOOK=${{ env.SLACK_WEBHOOK }} \
+      #     -v ${{ github.workspace }}/galasa:/galasa:rw \
+      #     ghcr.io/${{ env.NAMESPACE }}/galasabld-ibm:main \
+      #     slackpost tests \
+      #     --path /galasa/test.json \
+      #     --name "Simbank" \
+      #     --desc "Tests running locally on GitHub Actions" \
+      #     --hook ${{ env.SLACK_WEBHOOK }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,12 @@ jobs:
 
     steps:
     #----------------------------------------------------------------------------------
+      - name: Checkout the Simplatform repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.NAMESPACE }}/simplatform
+
+    #----------------------------------------------------------------------------------
     # Set up pre-requesite technology (Java, Gradle and galasactl)
       - name: Setup JDK
         uses: actions/setup-java@v4
@@ -91,17 +97,9 @@ jobs:
         with:
           name: simplatform
           path: /home/runner/.m2/repository
-        
-      - name: Checkout the Simplatform repository
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.NAMESPACE }}/simplatform
-          path: ${{ github.workspace }}/simplatform
 
       - name: Build SimBank using local build script
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        working-directory: ${{ github.workspace }}/simplatform
         run: |
           ./build-locally.sh --skip-docker --skip-secrets
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,6 +121,8 @@ jobs:
     #----------------------------------------------------------------------------------
     # Run the Simbank tests
       - name: Run the SimBankIVT
+        env:
+          GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
         run: |
           galasactl runs submit local \
           --obr mvn:dev.galasa/dev.galasa.simbank.obr/${GALASA_VERSION}/obr \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,12 +76,22 @@
     }
   ],
   "results": {
+    ".galasa/cps.properties": [
+      {
+        "hashed_secret": "877704f69026efee10f08e8f95568749f2682203",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     ".github/workflows/test.yaml": [
       {
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 85,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -75,7 +75,18 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
+  "results": {
+    ".github/workflows/test.yaml": [
+      {
+        "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
   "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -81,7 +81,7 @@
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 76,
+        "line_number": 74,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -81,7 +81,7 @@
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 76,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -9,6 +9,9 @@
 #
 # Objectives: Build this repository code locally.
 # 
+# Environment variable overrides:
+# SOURCE_MAVEN - Optional. Where a maven repository is from which the build will draw artifacts.
+# 
 #-----------------------------------------------------------------------------------------                   
 
 # Where is this script executing from ?
@@ -99,11 +102,11 @@ project=$(basename ${BASEDIR})
 h1 "Building ${project}"
 
 
-# Over-rode SOURCE_MAVEN if you want to build from a different maven repo...
+# Override SOURCE_MAVEN if you want to build from a different maven repo...
 if [[ -z ${SOURCE_MAVEN} ]]; then
     export SOURCE_MAVEN=https://development.galasa.dev/main/maven-repo/obr/
     info "SOURCE_MAVEN repo defaulting to ${SOURCE_MAVEN}."
-    info "Set this environment variable if you want to over-ride this value."
+    info "Set this environment variable if you want to override this value."
 else
     info "SOURCE_MAVEN set to ${SOURCE_MAVEN} by caller."
 fi
@@ -169,7 +172,7 @@ function check_secrets {
 function build_application_code {
     h1 "Building simplatform application using maven"
     cd ${BASEDIR}/galasa-simplatform-application
-    mvn clean install
+    mvn clean install -Dgalasa.source.repo=${SOURCE_MAVEN}
     rc=$?
     if [[ "${rc}" != "0" ]]; then 
         error "make clean install failed. rc=${rc}"
@@ -181,7 +184,7 @@ function build_application_code {
 function build_test_code {
     h1 "Building simbank tests using maven"
     cd ${BASEDIR}/galasa-simbank-tests
-    mvn clean install
+    mvn clean install -Dgalasa.source.repo=${SOURCE_MAVEN}
     rc=$?
     if [[ "${rc}" != "0" ]]; then 
         error "make clean install failed. rc=${rc}"

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -172,7 +172,10 @@ function check_secrets {
 function build_application_code {
     h1 "Building simplatform application using maven"
     cd ${BASEDIR}/galasa-simplatform-application
-    mvn clean install -Dgalasa.source.repo=${SOURCE_MAVEN}
+    mvn clean install \
+    -Dgalasa.source.repo=${SOURCE_MAVEN} \
+    -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+    --settings ${BASEDIR}/settings.xml
     rc=$?
     if [[ "${rc}" != "0" ]]; then 
         error "make clean install failed. rc=${rc}"
@@ -184,7 +187,10 @@ function build_application_code {
 function build_test_code {
     h1 "Building simbank tests using maven"
     cd ${BASEDIR}/galasa-simbank-tests
-    mvn clean install -Dgalasa.source.repo=${SOURCE_MAVEN}
+    mvn clean install \
+    -Dgalasa.source.repo=${SOURCE_MAVEN} \
+    -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+    --settings ${BASEDIR}/settings.xml
     rc=$?
     if [[ "${rc}" != "0" ]]; then 
         error "make clean install failed. rc=${rc}"

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -80,14 +80,22 @@ EOF
 #-----------------------------------------------------------------------------------------                   
 export build_type=""
 
+SKIP_DOCKER=false
+SKIP_SECRETS=false
+
 while [ "$1" != "" ]; do
     case $1 in
+        --skip-docker )         SKIP_DOCKER=true
+                                ;;
+        --skip-secrets )        SKIP_SECRETS=true
+                                ;;
         -h | --help )           usage
                                 exit
                                 ;;
         * )                     error "Unexpected argument $1"
                                 usage
                                 exit 1
+                                ;;
     esac
     shift
 done
@@ -213,5 +221,11 @@ function build_docker_image {
 
 build_application_code
 build_test_code
-build_docker_image
-check_secrets
+
+if [ "$SKIP_DOCKER" = false ]; then
+    build_docker_image
+fi
+
+if [ "$SKIP_SECRETS" = false ]; then
+    check_secrets
+fi

--- a/test-locally.sh
+++ b/test-locally.sh
@@ -7,7 +7,7 @@
 #
 #-----------------------------------------------------------------------------------------                   
 #
-# Objectives: Build this repository code locally.
+# Objectives: Run the Simbank tests locally.
 # 
 #-----------------------------------------------------------------------------------------                   
 
@@ -92,6 +92,89 @@ function checkGalasaCtlAvailable {
     fi
 }
 
+function checkSimBankTestAreBuilt {
+    SIMBANK_TESTS_PATH=$(ls ~/.m2/repository/dev/galasa/dev.galasa.simbank.tests/${SIMBANK_VERSION}/dev.galasa.simbank.tests-${SIMBANK_VERSION}.jar 2>/dev/null)
+
+    if [ -f "$SIMBANK_TESTS_PATH" ]; then
+        info "Found dev.galasa.simbank.tests in local Maven repo: $SIMBANK_TESTS_PATH"
+    else
+        error "dev.galasa.simbank.tests not found in local Maven repo." >&2
+        exit 1
+    fi
+}
+
+function checkSimBankAppIsBuilt {
+    SIMBANK_APP_PATH=$(ls ~/.m2/repository/dev/galasa/galasa-simplatform/${SIMBANK_VERSION}/galasa-simplatform-${SIMBANK_VERSION}.jar 2>/dev/null)
+
+    if [ -f "$SIMBANK_APP_PATH" ]; then
+        info "Found galasa-simplatform in local Maven repo: $SIMBANK_APP_PATH"
+    else
+        error "galasa-simplatform not found in local Maven repo." >&2
+        exit 1
+    fi
+}
+
+#-----------------------------------------------------------------------------------------                   
+# Test methods.
+#-----------------------------------------------------------------------------------------                   
+function runSimBankIVT {
+    cmd="galasactl runs submit local \
+    --obr mvn:dev.galasa/dev.galasa.simbank.obr/${TEST_OBR_VERSION}/obr \
+    --obr mvn:dev.galasa/dev.galasa.uber.obr/${TEST_OBR_VERSION}/obr \
+    --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT \
+    --log ${BASEDIR}/temp/simbank-test-log.txt"
+
+    info "Command is ${cmd}"
+
+    $cmd
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        error "Command to run tests failed. rc=${rc}. Log is at ${BASEDIR}/temp/log.txt"
+        exit 1
+    fi
+
+    success "Ran SimBankIVT test OK"
+}
+
+function runBasicAccountCreditTest {
+    cmd="galasactl runs submit local \
+    --obr mvn:dev.galasa/dev.galasa.simbank.obr/${TEST_OBR_VERSION}/obr \
+    --obr mvn:dev.galasa/dev.galasa.uber.obr/${TEST_OBR_VERSION}/obr \
+    --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest \
+    --log ${BASEDIR}/temp/simbank-test-log.txt"
+
+    info "Command is ${cmd}"
+
+    $cmd
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        error "Command to run tests failed. rc=${rc}. Log is at ${BASEDIR}/temp/log.txt"
+        exit 1
+    fi
+
+    success "Ran BasicAccountCreditTest test OK"
+}
+
+function runProvisionedAccountCreditTests {
+    cmd="galasactl runs submit local \
+    --obr mvn:dev.galasa/dev.galasa.simbank.obr/${TEST_OBR_VERSION}/obr \
+    --obr mvn:dev.galasa/dev.galasa.uber.obr/${TEST_OBR_VERSION}/obr \
+    --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.ProvisionedAccountCreditTests \
+    --log ${BASEDIR}/temp/simbank-test-log.txt"
+
+    info "Command is ${cmd}"
+
+    $cmd
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        error "Command to run tests failed. rc=${rc}. Log is at ${BASEDIR}/temp/log.txt"
+        exit 1
+    fi
+
+    success "Ran ProvisionedAccountCreditTests test OK"
+}
+
+
 #-----------------------------------------------------------------------------------------                   
 # Main logic.
 #-----------------------------------------------------------------------------------------                   
@@ -103,24 +186,23 @@ SIMBANK_VERSION="0.42.0"
 h1 "Running Simbank application tests"
 
 checkGalasaCtlAvailable
+checkSimBankTestAreBuilt
+checkSimBankAppIsBuilt
+
+# Start the Simbank back-end server application in a background process...
+h1 "Running Simbank back-end server application (version ${SIMBANK_VERSION}) ..."
+
+java -jar ~/.m2/repository/dev/galasa/galasa-simplatform/${SIMBANK_VERSION}/galasa-simplatform-${SIMBANK_VERSION}.jar > ${BASEDIR}/temp/simbank-app-log.txt 2>&1 &
+
+success "Simbank application started OK."
 
 TEST_OBR_VERSION="0.42.0"
 
 mkdir -p ${BASEDIR}/temp
 cd ${BASEDIR}/temp
 
-cmd="galasactl runs submit local \
---obr mvn:dev.galasa/dev.galasa.simbank.obr/${TEST_OBR_VERSION}/obr \
---class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SIMBANKIVT \
---log ${BASEDIR}/temp/log.txt"
+runSimBankIVT
+runBasicAccountCreditTest
+runProvisionedAccountCreditTests
 
-info "Command is ${cmd}"
-
-$cmd
-rc=$?
-if [[ "${rc}" != "0" ]]; then
-    error "Command to run tests failed. rc=${rc}. Log is at ${BASEDIR}/temp/log.txt"
-    exit 1
-fi
-
-success "Ran Simbank test OK"
+success "All SimBank tests Passed."


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2190

Part of the efforts to replace all the old inttests that rely on the Linux VMs with new tests.

- This PR adds a new GH workflow that runs the `SimBankIVT`, `BasicAccountCreditTest` and `ProvisionedAccountCreditTests`. This is the equivalent of what the inttest SimbankLocalJava11Ubuntu does so that test can be removed once this is merged. This workflow is called after every Main Build of the Simplatform repo, and will be called as part of a daily regression run at 6am.
- This PR also makes some updates to the build-locally.sh script so that it can be ran inside the Test Simbank workflow, but still functions as it did originally when ran locally.
- This PR also makes some updates to the test-locally.sh script which did not work - it can now run the `SimBankIVT`, `BasicAccountCreditTest` and `ProvisionedAccountCreditTests` locally.