### PR TITLE
Report results of Simbank tests into Slack channel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -154,13 +154,17 @@ jobs:
     # Combine test reports and report to Slack channel
       - name: Combine test reports
         # Skip this step for forks
-        if: ${{ github.repository_owner == 'galasa-dev' }}
+        # Only report results if this workflow was called from 
+        # a regression run as Main builds run multiple times a day.
+        if: ${{ github.repository_owner == 'galasa-dev' && github.event_name 'workflow_dispatch' }}
         run: |
           jq -s '{ tests: map(.tests[]) }' ${{ github.workspace }}/.galasa/temp/test-1.json ${{ github.workspace }}/.galasa/temp/test-2.json ${{ github.workspace }}/.galasa/temp/test-3.json > ${{ github.workspace }}/.galasa/temp/tests.json
 
       - name: Report results into Slack channel
-        # Skip this step for forks
-        if: ${{ github.repository_owner == 'galasa-dev' }}
+        # Skip this step for forks.
+        # Only report results if this workflow was called from 
+        # a regression run as Main builds run multiple times a day.
+        if: ${{ github.repository_owner == 'galasa-dev' && github.event_name 'workflow_dispatch' }}
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -123,6 +123,7 @@ jobs:
           --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \
           --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT \
           --remoteMaven https://development.galasa.dev/main/maven-repo/obr \
+          --reportjson ${{ github.workspace }}/.galasa/temp/test-1.json \
           --log -
 
       - name: Run the BasicAccountCreditTest
@@ -134,6 +135,7 @@ jobs:
           --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \
           --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest \
           --remoteMaven https://development.galasa.dev/main/maven-repo/obr \
+          --reportjson ${{ github.workspace }}/.galasa/temp/test-2.json \
           --log -
 
       - name: Run the ProvisionedAccountCreditTests
@@ -145,18 +147,29 @@ jobs:
           --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_VERSION}/obr \
           --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.ProvisionedAccountCreditTests \
           --remoteMaven https://development.galasa.dev/main/maven-repo/obr \
+          --reportjson ${{ github.workspace }}/.galasa/temp/test-3.json \
           --log -
 
-      # - name: Report results into Slack channel
-      #   env: 
-      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      #   run: |
-      #     docker run --rm \
-      #     --env SLACK_WEBHOOK=${{ env.SLACK_WEBHOOK }} \
-      #     -v ${{ github.workspace }}/galasa:/galasa:rw \
-      #     ghcr.io/${{ env.NAMESPACE }}/galasabld-ibm:main \
-      #     slackpost tests \
-      #     --path /galasa/test.json \
-      #     --name "Simbank" \
-      #     --desc "Tests running locally on GitHub Actions" \
-      #     --hook ${{ env.SLACK_WEBHOOK }}
+    #----------------------------------------------------------------------------------
+    # Combine test reports and report to Slack channel
+      - name: Combine test reports
+        # Skip this step for forks
+        if: ${{ github.repository_owner == 'galasa-dev' }}
+        run: |
+          jq -s '{ tests: map(.tests[]) }' ${{ github.workspace }}/.galasa/temp/test-1.json ${{ github.workspace }}/.galasa/temp/test-2.json ${{ github.workspace }}/.galasa/temp/test-3.json > ${{ github.workspace }}/.galasa/temp/tests.json
+
+      - name: Report results into Slack channel
+        # Skip this step for forks
+        if: ${{ github.repository_owner == 'galasa-dev' }}
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          docker run --rm \
+            --env SLACK_WEBHOOK=${{ env.SLACK_WEBHOOK }} \
+            -v ${{ github.workspace }}/.galasa/temp:/galasa:rw \
+            ghcr.io/${{ env.NAMESPACE }}/galasabld-ibm:main \
+            slackpost tests \
+            --path /galasa/tests.json \
+            --name "Simbank" \
+            --desc "Tests running locally on GitHub Actions" \
+            --hook ${{ env.SLACK_WEBHOOK }}

--- a/test-locally.sh
+++ b/test-locally.sh
@@ -183,11 +183,12 @@ source_dir="."
 project=$(basename ${BASEDIR})
 SIMBANK_VERSION="0.42.0"
 
-h1 "Running Simbank application tests"
-
 checkGalasaCtlAvailable
 checkSimBankTestAreBuilt
 checkSimBankAppIsBuilt
+
+mkdir -p ${BASEDIR}/temp
+cd ${BASEDIR}/temp
 
 # Start the Simbank back-end server application in a background process...
 h1 "Running Simbank back-end server application (version ${SIMBANK_VERSION}) ..."
@@ -198,8 +199,7 @@ success "Simbank application started OK."
 
 TEST_OBR_VERSION="0.42.0"
 
-mkdir -p ${BASEDIR}/temp
-cd ${BASEDIR}/temp
+h1 "Running Simbank tests"
 
 runSimBankIVT
 runBasicAccountCreditTest


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2190

Update Test Simbank workflow to create JSON reports for the Simbank tests and then combine them to one report, to be sent into the Slack channel.