### PR TITLE
fix: add missing workflow_dispatch trigger to Test Simbank workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,8 @@
 name: Test SimBank
 
 on:
+  # This workflow_dispatch is used in the release process.
+  workflow_dispatch:
   # This workflow_call is used after the Main Build of Simplatform.
   workflow_call:
   schedule:


### PR DESCRIPTION
## Why?

During the Galasa release process, a script is run which attempts to start the Test Simbank workflow with the `gh` CLI tool, however it did not work as the workflow needs a `workflow_dispatch` trigger to be called by the `gh` CLI.