### PR TITLE
Bump easymock dependency to remove vulnerability 

### DIFF
--- a/galasa-simplatform-application/pom.xml
+++ b/galasa-simplatform-application/pom.xml
@@ -127,6 +127,13 @@
 			</dependency>
 			<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 
+			<!-- Overrides the version of easymock 3.4 that gets pulled in transiently -->
+			<dependency>
+				<groupId>org.easymock</groupId>
+				<artifactId>easymock</artifactId>
+				<version>5.6.0</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2572

easymock 3.4 is pulled into the galasa-simplatform.jar due to the dependency chain (galasa-simplatform > dev.galasa.zos.manager > dev.galasa.framework > org.apache.felix.bundlerepository 2.0.10 > easymock 3.4). easymock 3.4 contains junit 4.12 which has a vulnerability. This could not be removed by bumping org.apache.felix.bundlerepository  as 2.0.10 is the most recent version, so this change explicitly defines an easymock dependency on 5.6 so that 3.4 does not get pulled in through the dependency chain.

This change has been tested by building Simplatform locally, then building Isolated locally, checking the contents of galasa-simplatform.jar by inflating it with `jar -xvf` and verifying that the easymock version pulled in is 5.6.

I have also ran all of the Simbank tests locally to make sure no OSGi/versioning problems were introduced.

## Changes
- [x] Dependency on easymock 5.6 added to the galasa-simplatform-parent
