### PR TITLE
Iss2569 - Fix recent 401 responses in BatchAccountsOpenTest and WebAppIntegrationTest

### DIFF
--- a/galasa-simplatform-application/galasa-simplatform-3270/src/main/java/dev/galasa/simplatform/listener/ManagementFacilityListener.java
+++ b/galasa-simplatform-application/galasa-simplatform-3270/src/main/java/dev/galasa/simplatform/listener/ManagementFacilityListener.java
@@ -49,8 +49,9 @@ public class ManagementFacilityListener implements IListener {
 	private static final String HEADER_HTTP_400_BAD_REQUEST = "HTTP/1.1 400 Bad Request";
 	private static final String HEADER_HTTP_401_UNAUTHORIZED = "HTTP/1.1 401 Unauthorized";
 	private static final String HEADER_HTTP_404_NOT_FOUND = "HTTP/1.1 404 Not Found";
-	private static final String HEADER_HTTP_500_INTERNAL_SERVER_ERROR = "HTTP/1.1 500 Internal Server Error"; 
+	private static final String HEADER_HTTP_500_INTERNAL_SERVER_ERROR = "HTTP/1.1 500 Internal Server Error";
 	private static final String HEADER_SERVER = "Server: Simplatform  " + Simplatform.getVersion();
+	private static final String HEADER_WWW_AUTHENTICATE = "WWW-Authenticate: Basic realm=\"Simplatform\"";
 	private static final String HEADER_CONNECTION_CLOSE = "Connection: close";
 	private static final String HEADER_CONTENT_LENGTH = "Content-Length: ";
 	private static final String HEADER_CONTENT_TYPE_TEXT = "Content-Type: text/plain; charset=\"utf-8\"" + CR_LF;
@@ -292,6 +293,7 @@ public class ManagementFacilityListener implements IListener {
 		PrintStream ps = new PrintStream(output);
 		ps.println(HEADER_HTTP_401_UNAUTHORIZED);
 		ps.println(HEADER_SERVER);
+		ps.println(HEADER_WWW_AUTHENTICATE);
 		ps.println(HEADER_CONNECTION_CLOSE);
 		ps.println(CR_LF);
 		ps.flush();


### PR DESCRIPTION
## Why?

Fixes https://github.com/galasa-dev/projectmanagement/issues/2569

This PR adds the missing HTTP Basic Auth challenge header to the 401 response that is returned from the `ManagementFacilityListener` (simulated z/OS MF REST API server). This prompts the HTTP Manager to retry the request with Basic Auth credentials. This is needed since recent changes to the HTTP Manager code which removes the preemptive auth cache which automatically added the header to the first request.

## Changes
- [x] HTTP Basic Auth challenge header added to 401 response from `ManagementFacilityListener`
- [x] Changes tested by running the BatchAccountsOpenTest and WebAppIntegrationTest tests locally
